### PR TITLE
Style trip preview

### DIFF
--- a/Components/TripPreview/TripPreview.js
+++ b/Components/TripPreview/TripPreview.js
@@ -1,25 +1,26 @@
 import React from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import { Text, View, StyleSheet, TouchableOpacity } from 'react-native';
 
 export const TripPreview = ({ route }) => {
   const { name, startDate, endDate, originAbbrev, finalDestinationAbbrev, description, destinations } = route.params;
 
   let displayDestinations = destinations.map(destination => {
     return (
-      <View styles={styles.destination}>
-        <Text style={{ fontSize: 40 }}>{destination.location}</Text>
-        <Text>{destination.startDate}</Text>
-        <Text>{destination.endDate}</Text>
-      </View>
+      <TouchableOpacity onPress={() => console.log('hi')}>
+        <View style={styles.destination}>
+          <Text style={{ fontSize: 40 }}>{destination.location}</Text>
+          <View style={styles.destinationDates}>
+            <Text>{destination.startDate}</Text>
+            <Text>{destination.endDate}</Text>
+          </View>
+        </View>
+      </TouchableOpacity>
     )
   })
 
   return (
     <View style={styles.container}>
       <Text style={styles.name}>{name}</Text>
-      <View style={styles.description}>
-        <Text>Notes: {description}</Text>
-      </View>
       <View style={styles.tripOverview}>
         <View style={styles.cityContainer}>
           <Text style={{ fontSize: 40 }}>{originAbbrev}</Text>
@@ -31,7 +32,10 @@ export const TripPreview = ({ route }) => {
           <Text>{endDate}</Text>
         </View>
       </View>
-      <View styles={styles.destinationsContainer}>
+      <View style={styles.description}>
+        <Text>Notes: {description}</Text>
+      </View>
+      <View style={styles.destinationsContainer}>
         {
           destinations.length ?
             displayDestinations :
@@ -48,13 +52,14 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingBottom: 40,
     backgroundColor: '#c9e2ef',
-    justifyContent: 'flex-start'
+    justifyContent: 'flex-start',
+    alignItems: 'center'
   },
   tripOverview: {
-    flex: 1,
     flexDirection: 'row',
     justifyContent: 'space-around',
-    alignItems: 'center'
+    alignItems: 'center',
+    width: '100%'
   },
   name: {
     alignItems: 'center',
@@ -79,8 +84,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-around'
   },
-  destination: {
-    alignItems: 'center'
+  destinationDates: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-around'
+  },
+  destinationContainer: {
+    height: '100%',
+    justifyContent: 'space-around'
   }
 })
 

--- a/Components/TripPreview/TripPreview.js
+++ b/Components/TripPreview/TripPreview.js
@@ -8,10 +8,10 @@ export const TripPreview = ({ route }) => {
     <View style={styles.container}>
       <Text style={styles.name}>{name}</Text>
       <View style={styles.cities}>
-        <Text style={styles.origin}>{originAbbrev}</Text>
-        <Text style={styles.destination}>{finalDestinationAbbrev}</Text>
+        <Text style={{fontSize: 40}}>{originAbbrev}</Text>
+        <Text style={{fontSize: 40}}>{finalDestinationAbbrev}</Text>
       </View>
-      <View style={styles.cities}>
+      <View style={styles.dates} >
         <Text style={styles.startDate}>{startDate}</Text>
         <Text style={styles.endDate}>{endDate}</Text>
       </View>
@@ -24,26 +24,33 @@ export const TripPreview = ({ route }) => {
 
 const styles = StyleSheet.create({
   container: {
-    borderColor: 'black',
-    borderRadius: 5,
-    borderWidth: 1,
-    marginTop: 10,
-    padding: 10
+    padding: 10,
+    flex: 1,
+    paddingBottom: 40,
+    backgroundColor: '#c9e2ef'
   },
   name: {
     alignItems: 'center',
-    fontSize: 20,
+    fontSize: 40,
     fontWeight: 'bold',
     margin: 'auto',
-    marginBottom: 5
+    marginBottom: 20
   },
   cities: {
     flex: 1,
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'space-around',
+    marginBottom: -200
   },
   description: {
     margin: 'auto',
+    justifyContent: 'center',
+    fontSize: 10
+  },
+  dates: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-around'
   }
 })
 

--- a/Components/TripPreview/TripPreview.js
+++ b/Components/TripPreview/TripPreview.js
@@ -6,7 +6,7 @@ export const TripPreview = ({ route }) => {
 
   let displayDestinations = destinations.map(destination => {
     return (
-      <View styles={styles.cityContainer}>
+      <View styles={styles.destination}>
         <Text style={{ fontSize: 40 }}>{destination.location}</Text>
         <Text>{destination.startDate}</Text>
         <Text>{destination.endDate}</Text>
@@ -17,6 +17,9 @@ export const TripPreview = ({ route }) => {
   return (
     <View style={styles.container}>
       <Text style={styles.name}>{name}</Text>
+      <View style={styles.description}>
+        <Text>Notes: {description}</Text>
+      </View>
       <View style={styles.tripOverview}>
         <View style={styles.cityContainer}>
           <Text style={{ fontSize: 40 }}>{originAbbrev}</Text>
@@ -28,14 +31,13 @@ export const TripPreview = ({ route }) => {
           <Text>{endDate}</Text>
         </View>
       </View>
-      <View style={styles.description}>
-        <Text>Notes: {description}</Text>
+      <View styles={styles.destinationsContainer}>
+        {
+          destinations.length ?
+            displayDestinations :
+            <Text>No Other Destinations</Text>
+        }
       </View>
-      {
-        destinations.length ?
-          displayDestinations :
-          <Text>No Other Destinations</Text>
-      }
     </View>
   )
 }
@@ -76,6 +78,9 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'space-around'
+  },
+  destination: {
+    alignItems: 'center'
   }
 })
 

--- a/Components/TripPreview/TripPreview.js
+++ b/Components/TripPreview/TripPreview.js
@@ -2,22 +2,40 @@ import React from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 
 export const TripPreview = ({ route }) => {
-  const { name, startDate, endDate, originAbbrev, finalDestinationAbbrev, description } = route.params;
+  const { name, startDate, endDate, originAbbrev, finalDestinationAbbrev, description, destinations } = route.params;
+
+  let displayDestinations = destinations.map(destination => {
+    return (
+      <View styles={styles.cityContainer}>
+        <Text style={{ fontSize: 40 }}>{destination.location}</Text>
+        <Text>{destination.startDate}</Text>
+        <Text>{destination.endDate}</Text>
+      </View>
+    )
+  })
 
   return (
     <View style={styles.container}>
       <Text style={styles.name}>{name}</Text>
-      <View style={styles.cities}>
-        <Text style={{fontSize: 40}}>{originAbbrev}</Text>
-        <Text style={{fontSize: 40}}>{finalDestinationAbbrev}</Text>
-      </View>
-      <View style={styles.dates} >
-        <Text style={styles.startDate}>{startDate}</Text>
-        <Text style={styles.endDate}>{endDate}</Text>
+      <View style={styles.tripOverview}>
+        <View style={styles.cityContainer}>
+          <Text style={{ fontSize: 40 }}>{originAbbrev}</Text>
+          <Text>{startDate}</Text>
+        </View>
+        <Text style={{ fontSize: 20 }}>to</Text>
+        <View style={styles.cityContainer}>
+          <Text style={{ fontSize: 40 }}>{finalDestinationAbbrev}</Text>
+          <Text>{endDate}</Text>
+        </View>
       </View>
       <View style={styles.description}>
         <Text>Notes: {description}</Text>
       </View>
+      {
+        destinations.length ?
+          displayDestinations :
+          <Text>No Other Destinations</Text>
+      }
     </View>
   )
 }
@@ -27,7 +45,14 @@ const styles = StyleSheet.create({
     padding: 10,
     flex: 1,
     paddingBottom: 40,
-    backgroundColor: '#c9e2ef'
+    backgroundColor: '#c9e2ef',
+    justifyContent: 'flex-start'
+  },
+  tripOverview: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center'
   },
   name: {
     alignItems: 'center',
@@ -36,11 +61,11 @@ const styles = StyleSheet.create({
     margin: 'auto',
     marginBottom: 20
   },
-  cities: {
+  citiesContainer: {
     flex: 1,
     flexDirection: 'row',
     justifyContent: 'space-around',
-    marginBottom: -200
+    alignItems: 'center'
   },
   description: {
     margin: 'auto',

--- a/Components/Trips/Trips.js
+++ b/Components/Trips/Trips.js
@@ -15,7 +15,19 @@ const mockPreviews = [
     finalDestination: 'paris, france',
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'PAR',
-    description: 'Spring Break Lorem Ipsum something de lor'
+    description: 'Spring Break Lorem Ipsum something de lor',
+    destinations: [
+      {
+        location: 'New York, NY',
+        startDate: '03-02-10',
+        endDate: '05-05-50'
+      },
+      {
+        location: 'pittsburgh, PA ',
+        startDate: '06-02-10',
+        endDate: '07-05-50'
+      }
+    ]
   },
   {
     id: '2',
@@ -26,7 +38,19 @@ const mockPreviews = [
     finalDestination: 'Barcelona, spain',
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'BRC',
-    description: 'Summer Roadtrip Lorem Ipsum something de lor'
+    description: 'Summer Roadtrip Lorem Ipsum something de lor',
+    destinations: [
+      {
+        location: 'New York, NY',
+        startDate: '03-02-10',
+        endDate: '05-05-50'
+      },
+      {
+        location: 'pittsburgh, PA ',
+        startDate: '06-02-10',
+        endDate: '07-05-50'
+      }
+    ]
   },
   {
     id: '3',
@@ -37,7 +61,19 @@ const mockPreviews = [
     finalDestination: 'Tokyo, Japan',
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
-    description: ' Winter Lorem Ipsum something de lor'
+    description: ' Winter Lorem Ipsum something de lor',
+    destinations: [
+      {
+        location: 'New York, NY',
+        startDate: '03-02-10',
+        endDate: '05-05-50'
+      },
+      {
+        location: 'pittsburgh, PA ',
+        startDate: '06-02-10',
+        endDate: '07-05-50'
+      }
+    ]
   },
   {
     id: '4',
@@ -48,7 +84,19 @@ const mockPreviews = [
     finalDestination: 'Tokyo, Japan',
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
-    description: 'Lorem Ipsum something de lor'
+    description: 'Lorem Ipsum something de lor',
+    destinations: [
+      {
+        location: 'New York, NY',
+        startDate: '03-02-10',
+        endDate: '05-05-50'
+      },
+      {
+        location: 'pittsburgh, PA ',
+        startDate: '06-02-10',
+        endDate: '07-05-50'
+      }
+    ]
   },
   {
     id: '5',
@@ -59,7 +107,19 @@ const mockPreviews = [
     finalDestination: 'Tokyo, Japan',
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
-    description: 'Lorem Ipsum something de lor'
+    description: 'Lorem Ipsum something de lor',
+    destinations: [
+      {
+        location: 'New York, NY',
+        startDate: '03-02-10',
+        endDate: '05-05-50'
+      },
+      {
+        location: 'pittsburgh, PA ',
+        startDate: '06-02-10',
+        endDate: '07-05-50'
+      }
+    ]
   },
   {
     id: '6',
@@ -70,7 +130,8 @@ const mockPreviews = [
     finalDestination: 'Tokyo, Japan',
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
-    description: 'Lorem Ipsum something de lor'
+    description: 'Lorem Ipsum something de lor',
+    
   },
   {
     id: '7',
@@ -81,7 +142,8 @@ const mockPreviews = [
     finalDestination: 'Tokyo, Japan',
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
-    description: 'Lorem Ipsum something de lor'
+    description: 'Lorem Ipsum something de lor',
+    
   },
   {
     id: '8',
@@ -92,7 +154,8 @@ const mockPreviews = [
     finalDestination: 'Tokyo, Japan',
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
-    description: 'Lorem Ipsum something de lor'
+    description: 'Lorem Ipsum something de lor',
+    
   },
   {
     id: '9',
@@ -103,7 +166,8 @@ const mockPreviews = [
     finalDestination: 'Tokyo, Japan',
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
-    description: 'Lorem Ipsum something de lor'
+    description: 'Lorem Ipsum something de lor',
+    
   },
   {
     id: '10',

--- a/Components/Trips/Trips.js
+++ b/Components/Trips/Trips.js
@@ -131,7 +131,7 @@ const mockPreviews = [
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
     description: 'Lorem Ipsum something de lor',
-    
+    destinations: []
   },
   {
     id: '7',
@@ -143,7 +143,7 @@ const mockPreviews = [
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
     description: 'Lorem Ipsum something de lor',
-    
+    destinations: []
   },
   {
     id: '8',
@@ -155,7 +155,7 @@ const mockPreviews = [
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
     description: 'Lorem Ipsum something de lor',
-    
+    destinations: []
   },
   {
     id: '9',
@@ -167,7 +167,7 @@ const mockPreviews = [
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
     description: 'Lorem Ipsum something de lor',
-    
+    destinations: []
   },
   {
     id: '10',
@@ -178,7 +178,8 @@ const mockPreviews = [
     finalDestination: 'Tokyo, Japan',
     originAbbrev: 'DEN',
     finalDestinationAbbrev: 'TOK',
-    description: 'Lorem Ipsum something de lor'
+    description: 'Lorem Ipsum something de lor',
+    destinations: []
   }
 ];
 


### PR DESCRIPTION
#### What's this PR do?
- This PR is mostly a styling PR, organizing the tripPreview component to nicely display all destinations and dates, as well as notes for a given trip in a logical fashion
- It also modifies the mock data to include an array of destinations, so that I can iteration over them, and display each of them to the user, or, if no additional destinations, confirm that to the user.
- I wrapped each destination in a TouchableOpacity for eventual navigation to the Locations view
#### Where should the reviewer start?
- Take a look at TripPreview to check the conditional render. This ensures that if there are destinations, they will each be rendered to the user.
#### How should this be manually tested?
- Click on a trip at the top to view it's destinations. The last two trips don't have any destinations, so you can look there to see that message.
#### Any background context you want to provide?
- The styling is pretty basic at this point, but I'm moving on to the next piece of functionality. As much as I like styling, our sprint should be focused on that MVP, regardless of the styling.
#### What are the relevant tickets?
- Closes #27 
#### Screenshots (if appropriate):
- ![2020-02-19 13 39 44](https://user-images.githubusercontent.com/49926352/74873945-58f79900-531d-11ea-8f57-f6ba7a007653.gif)
#### Questions
- We will have a locations view for each destination on the trip, including the origin and the final destination. Currently those are not rendered as buttons. I will modify this on my next branch (navigation to locations)
